### PR TITLE
add prefix and suffix to display name mappings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -47,6 +47,16 @@ def load_nodes_from_directory(package_path):
                                 display_name = " ".join(
                                     word.capitalize() for word in re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z][a-z]|\d|\W|$)|\d+", name)
                                 )
+                                
+                                # Add prefix if defined
+                                if hasattr(obj, "NAME_PREFIX"):
+                                    display_name = f"{obj.NAME_PREFIX} {display_name}"
+                                
+                                # Add suffix if defined
+                                if hasattr(obj, "NAME_SUFFIX"):
+                                    display_name = f"{display_name} {obj.NAME_SUFFIX}"
+                                
+                                # Add the realtime suffix
                                 suffix = " 🕒🅡🅣🅝"
                                 if not display_name.endswith(suffix):
                                     display_name += suffix
@@ -111,6 +121,15 @@ for node_name in NODE_CLASS_MAPPINGS.keys():
     # Convert camelCase or snake_case to Title Case
     if node_name not in NODE_DISPLAY_NAME_MAPPINGS:
         display_name = " ".join(word.capitalize() for word in re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z][a-z]|\d|\W|$)|\d+", node_name))
+        
+        # Add prefix if defined
+        node_class = NODE_CLASS_MAPPINGS[node_name]
+        if hasattr(node_class, "NAME_PREFIX"):
+            display_name = f"{node_class.NAME_PREFIX} {display_name}"
+        
+        # Add suffix if defined
+        if hasattr(node_class, "NAME_SUFFIX"):
+            display_name = f"{display_name} {node_class.NAME_SUFFIX}"
     else:
         display_name = NODE_DISPLAY_NAME_MAPPINGS[node_name]
 

--- a/node_wrappers/realtimenodes/controls/state_management_controls.py
+++ b/node_wrappers/realtimenodes/controls/state_management_controls.py
@@ -22,7 +22,7 @@ class StateResetNode(ControlNodeBase):
     RETURN_TYPES = ("BOOLEAN",)
     FUNCTION = "update"
     CATEGORY = "Realtime Nodes/control/utility"
-
+    NAME_SUFFIX = "(BETA)"
     def update(self, trigger, always_execute=True):
         if trigger:
             self.state_manager.clear_all_states()
@@ -49,7 +49,8 @@ class StateTestNode(ControlNodeBase):
     RETURN_TYPES = ("INT",)
     FUNCTION = "update"
     CATEGORY = "Realtime Nodes/control/utility"
-
+    NAME_SUFFIX = "(BETA)"
+    
     def update(self, increment, always_execute=True):
         state = self.get_state({"counter": 0})
 
@@ -70,6 +71,7 @@ class GetStateNode(ControlNodeBase):
     RETURN_NAMES = ("value",)
     FUNCTION = "update"
     DESCRIPTION = "Retrieve a value from the global state using the given key. If the key is not found, return the default value."
+    NAME_SUFFIX = "(BETA)"
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -127,7 +129,7 @@ class SetStateNode(ControlNodeBase):
     DESCRIPTION = (
         "Store a value in the global state with the given key. The value will be accessible in future workflow runs through GetStateNode."
     )
-
+    NAME_SUFFIX = "(BETA)"
     @classmethod
     def INPUT_TYPES(cls):
         inputs = super().INPUT_TYPES()


### PR DESCRIPTION
# Add NAME_PREFIX and NAME_SUFFIX Support for Node Display Names

## Description
This PR adds support for `NAME_PREFIX` and `NAME_SUFFIX` class attributes in node classes, allowing developers to add custom prefixes and suffixes to node display names. This is particularly useful for marking nodes as beta, experimental, or adding other status indicators.

## Changes
- Added support for `NAME_PREFIX` and `NAME_SUFFIX` class attributes
- Modified display name generation to include these attributes in the correct order
- Maintains backward compatibility with existing nodes

## Usage Example
```python
class YourNode:
    NAME_PREFIX = "(BETA)"  # Optional
    NAME_SUFFIX = "(EXPERIMENTAL)"  # Optional
    CATEGORY = "Your Category"
    # ... rest of your node class
```

The display name will be generated as: `(BETA) Your Node (EXPERIMENTAL) 🕒🅡🅣🅝`

## Testing
- Verified that nodes without prefix/suffix attributes display correctly
- Confirmed that nodes with prefix/suffix attributes display in the correct order
- Ensured the realtime suffix (🕒🅡🅣🅝) is always appended last