### PR TITLE
Added support for category_allowlist and category_denylist

### DIFF
--- a/node_wrappers/mediapipe_vision/object_detection/object_detection.py
+++ b/node_wrappers/mediapipe_vision/object_detection/object_detection.py
@@ -53,6 +53,22 @@ class MediaPipeObjectDetectorNode(BaseMediaPipeDetectorNode):
                     "INT",
                     {"default": 5, "min": 1, "max": 50, "step": 1, "tooltip": "Maximum number of objects to detect"},
                 ),
+                "category_allowlist": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "multiline": False,
+                        "tooltip": "Comma-separated list of categories to detect (e.g., 'person,cat'). Empty means all categories.",
+                    },
+                ),
+                "category_denylist": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "multiline": False,
+                        "tooltip": "Comma-separated list of categories to exclude. Empty means not to exclude any categories.",
+                    },
+                ),
             }
         )
 
@@ -64,6 +80,8 @@ class MediaPipeObjectDetectorNode(BaseMediaPipeDetectorNode):
         model_info: dict,
         min_confidence: float,
         max_results: int,
+        category_allowlist: str,
+        category_denylist: str,
         running_mode: str,
         delegate: str,
     ):
@@ -75,9 +93,19 @@ class MediaPipeObjectDetectorNode(BaseMediaPipeDetectorNode):
         # Initialize or update detector
         detector = self.initialize_or_update_detector(model_path)
 
+        # Parse the allow / deny list string into a list, or None if empty
+        allowed_categories = [cat.strip() for cat in category_allowlist.split(',') if cat.strip()] or None
+        denied_categories = [cat.strip() for cat in category_denylist.split(',') if cat.strip()] or None
+
         # Perform detection with all parameters
         batch_results = detector.detect(
-            image, score_threshold=min_confidence, max_results=max_results, running_mode=running_mode, delegate=delegate
+            image,
+            score_threshold=min_confidence,
+            max_results=max_results,
+            category_allowlist=allowed_categories,
+            category_denylist=denied_categories,
+            running_mode=running_mode,
+            delegate=delegate
         )
 
         return (batch_results,)

--- a/src/mediapipe_vision/object_detection/detector.py
+++ b/src/mediapipe_vision/object_detection/detector.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, List, Optional
 
 import mediapipe as mp
 import numpy as np
@@ -40,6 +40,8 @@ class ObjectDetector(BaseDetector[ObjectDetectionResult]):
             running_mode=mode_enum,
             score_threshold=kwargs.get('score_threshold', 0.5),
             max_results=kwargs.get('max_results', 5),
+            category_allowlist=kwargs.get('category_allowlist', None),
+            category_denylist=kwargs.get('category_denylist', None),
         )
 
     def _create_detector_instance(self, options: vision.ObjectDetectorOptions) -> vision.ObjectDetector:
@@ -89,6 +91,8 @@ class ObjectDetector(BaseDetector[ObjectDetectionResult]):
         image: torch.Tensor,
         score_threshold: float = 0.5,
         max_results: int = 5,
+        category_allowlist: Optional[List[str]] = None,
+        category_denylist: Optional[List[str]] = None,
         running_mode: str = "video",
         delegate: str = "cpu",
     ) -> List[List[ObjectDetectionResult]]:
@@ -99,4 +103,6 @@ class ObjectDetector(BaseDetector[ObjectDetectionResult]):
             delegate=delegate,
             score_threshold=score_threshold,
             max_results=max_results,
+            category_allowlist=category_allowlist,
+            category_denylist=category_denylist,
         )


### PR DESCRIPTION
This PR adds support for the `category_allowlist` and `category_denylist` params of the object detector. Default value for both params is blank which retains the original functionality.